### PR TITLE
Write initializer to unique location

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -66,7 +66,7 @@ done
 
 topic "Writing profile script"
 mkdir -p $BUILD_DIR/.profile.d
-cat <<EOF >$BUILD_DIR/.profile.d/000_apt.sh
+cat <<EOF >$BUILD_DIR/.profile.d/puppeteer.sh
 export LD_LIBRARY_PATH="\$HOME/.apt/usr/lib/x86_64-linux-gnu:\$HOME/.apt/usr/lib/i386-linux-gnu:\$HOME/.apt/usr/lib:\$LD_LIBRARY_PATH"
 export LIBRARY_PATH="\$HOME/.apt/usr/lib/x86_64-linux-gnu:\$HOME/.apt/usr/lib/i386-linux-gnu:\$HOME/.apt/usr/lib:\$LIBRARY_PATH"
 export INCLUDE_PATH="\$HOME/.apt/usr/include:\$HOME/.apt/usr/include/x86_64-linux-gnu:\$INCLUDE_PATH"


### PR DESCRIPTION
`$BUILD_DIR/.profile.d/000_apt.sh` is also written to by [heroku-buildpack-apt](https://github.com/heroku/heroku-buildpack-apt/blob/2986b01ba873bc0da5f5d93001c618a9a3f0498f/bin/compile#L84), and that buildpack additionally modifies `$PATH`. Therefore, if using both buildpacks, `$PATH` might not be set correctly (perhaps depending on the order in which the buildpacks are listed in `app.json`).

This change writes the initializer to a distinct location, `$BUILD_DIR/.profile.d/puppeteers.sh`. I didn't bother with the `000_` prefix, because according to the [documentation](https://devcenter.heroku.com/articles/buildpack-api#profile-d-scripts):

> No guarantee is made regarding the order in which the scripts are sourced.