### PR TITLE
Don't use deprecated `apt-get --force-yes`

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -53,7 +53,7 @@ for PACKAGE in $PACKAGES; do
     curl -s -L -z $PACKAGE_FILE -o $PACKAGE_FILE $PACKAGE 2>&1 | indent
   else
     topic "Fetching .debs for $PACKAGE"
-    apt-get $APT_OPTIONS -y --force-yes -d install --reinstall $PACKAGE | indent
+    apt-get $APT_OPTIONS -y --allow-downgrades --allow-remove-essential --allow-change-held-packages -d install --reinstall $PACKAGE | indent
   fi
 done
 


### PR DESCRIPTION
I noticed in my heroku build log that there's a bunch of `apt-get` warnings like this:

```
W: --force-yes is deprecated, use one of the options starting with --allow instead.
```

It looks like this line is the one responsible: https://github.com/jontewks/puppeteer-heroku-buildpack/blob/22c5b5960775a5befb89e8b9a1014bc8c1187e3f/bin/compile#L56

According to the [`apt-get` man page](https://manpages.debian.org/stretch/apt/apt-get.8.en.html),
we can use `--allow-downgrades --allow-remove-essential --allow-change-held-packages` instead.

Fixes https://github.com/jontewks/puppeteer-heroku-buildpack/issues/29