### PR TITLE
Add the buildpack non-destructively

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Installs dependencies needed in order to run puppeteer on heroku. Be sure to inc
 To use the latest stable version run:
 
 ```sh-session
-$ heroku buildpacks:set jontewks/puppeteer
+$ heroku buildpacks:add jontewks/puppeteer
 ```
 
 Or use the source code in this repository:
 
 ```sh-session
-$ heroku buildpacks:set https://github.com/jontewks/puppeteer-heroku-buildpack.git
+$ heroku buildpacks:add https://github.com/jontewks/puppeteer-heroku-buildpack.git
 ```
 
 ### Additional language support


### PR DESCRIPTION
It's an awesome repo you have and certainly saved my day using Puppeteer along with Heroku!

However, when reading the Readme, I used the command in the usage guide, which overwrote my default heroku/nodejs builder in the project, causing my project to stop building.

In this PR I propose guiding users to instead add the buildpack without replacing whatever buildpacks they currently have.