### PR TITLE
Add `-o pipefail` to compile script

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -2,7 +2,7 @@
 # bin/compile <build-dir> <cache-dir>
 
 # fail fast
-set -e
+set -eo pipefail
 
 # debug
 # set -x


### PR DESCRIPTION
Without this, anything piped to the `indent` function (or any piped command at all) would fail silently.