### PR TITLE
Added note about puppeteer version restrictions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # puppeteer-heroku-buildpack
 
+## Note: only works for ```puppeteer``` version ≤ ```18```. For ```puppeteer``` version ≥ ```19``` use [heroku-buildpack-google-chrome](https://elements.heroku.com/buildpacks/heroku/heroku-buildpack-google-chrome)
+
 Installs dependencies needed in order to run puppeteer on heroku. Be sure to include `{ args: ['--no-sandbox'] }` in your call to `puppeteer.launch`.
 
 Puppeteer defaults to `headless: true` in `puppeteer.launch` and this shouldn't be changed. Heroku doesn't have a GUI to show you chrome when running `headless: false` and Heroku will throw an error.


### PR DESCRIPTION
Closes #128

Figured I'd get the conversation going about how to best address this issue. For now added a note but I wonder if this buildpack can be adjusted to accomodate ```puppeteer```version ```19``` and above? Or if maybe the best thing is to leave a note like this on the README so that people avoid having to dive into the issues. I took a look at tweaking the source myself but it's outside my current bash scripting level as well as my understanding of how puppeteer works under the hood.