### PR TITLE
heroku-26 support

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -91,7 +91,7 @@ case "${STACK}" in
       libxtst6
     "
     ;;
-  "heroku-24")
+  "heroku-24" | "heroku-26")
     PACKAGES="
       fonts-liberation
       libasound2t64
@@ -125,7 +125,7 @@ case "${STACK}" in
     "
     ;;
   *)
-    error "STACK must be 'heroku-20', 'heroku-22' or 'heroku-24', not '${STACK}'."
+    error "STACK must be 'heroku-20', 'heroku-22', 'heroku-24' or 'heroku-26', not '${STACK}'."
 esac
 
 APT_OPTIONS="-o debug::nolocking=true -o dir::cache=$APT_CACHE_DIR -o dir::state=$APT_STATE_DIR"

--- a/bin/compile
+++ b/bin/compile
@@ -58,7 +58,7 @@ mkdir -p "$APT_CACHE_DIR/archives/partial"
 mkdir -p "$APT_STATE_DIR/lists/partial"
 
 case "${STACK}" in
-  "heroku-20" | "heroku-22")
+  "heroku-22")
     PACKAGES="
       fonts-liberation
       libasound2
@@ -125,7 +125,7 @@ case "${STACK}" in
     "
     ;;
   *)
-    error "STACK must be 'heroku-20', 'heroku-22', 'heroku-24' or 'heroku-26', not '${STACK}'."
+    error "STACK must be 'heroku-22', 'heroku-24' or 'heroku-26', not '${STACK}'."
 esac
 
 APT_OPTIONS="-o debug::nolocking=true -o dir::cache=$APT_CACHE_DIR -o dir::state=$APT_STATE_DIR"


### PR DESCRIPTION
The heroku-26 stack was released a couple of weeks ago: https://devcenter.heroku.com/changelog-items/3703

This seems to be all that's required to support it. I've checked

* [x] The build passes on heroku
* [x] I can run our flows and tests that use puppeteer fine

I'm not sure what other testing needs to be done